### PR TITLE
'ReferenceError: window is not defined' error fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,2 +1,4 @@
+var window = require('global/window');
+
 var Context = window.AudioContext || window.webkitAudioContext;
 if (Context) module.exports = new Context;

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "url": "git://github.com/juliangruber/audio-context.git"
   },
   "homepage": "https://github.com/juliangruber/audio-context",
-  "dependencies": {},
+  "dependencies": {
+    "global": "~4.2.1"
+  },
   "devDependencies": {
     "tape": "*"
   },


### PR DESCRIPTION
Running `node test.js` would fail as `window` is not a global variable.

This PR does two things:
- the module is now testable in a non-browser environment
- the module sets its dependency on the global `window` object through the [global](https://www.npmjs.org/package/global) module

![](http://ljdchost.com/pD99niY.gif)
