### PR TITLE
Fallback to constructor w/o args to cover for Firefox bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,15 @@ module.exports = function getContext (options) {
 
 	if (ctx) return ctx
 
-	ctx = new Context(options)
+	//several versions of firefox have issues with the
+	//constructor argument
+	//see: https://bugzilla.mozilla.org/show_bug.cgi?id=1361475
+	try {
+		ctx = new Context(options)
+	}
+	catch (err) {
+		ctx = new Context()
+	}
 	cache[ctx.sampleRate] = cache[sampleRate] = ctx
 
 	return ctx


### PR DESCRIPTION
As [reported in this Bugzilla ticket](https://bugzilla.mozilla.org/show_bug.cgi?id=1361475), Firefox throws an error when `AudioContext()` is called with something that is not "an enumeration of `AudioChannel`". This is not spec compliant, and has been addressed.

However, since everyone won't be upgrading to the newest version immediately or at all, this fix makes sure `audio-context` works.