### PR TITLE
Remove dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,14 +1,14 @@
 'use strict'
 
-var window = require('global/window')
-
-var OfflineContext = window.OfflineAudioContext || window.webkitOfflineAudioContext
-var Context = window.AudioContext || window.webkitAudioContext
-
 var cache = {}
 
 module.exports = function getContext (options) {
-	if (!Context) return null
+  if (!window) return null
+  
+  var OfflineContext = window.OfflineAudioContext || window.webkitOfflineAudioContext
+  var Context = window.AudioContext || window.webkitAudioContext
+  
+  if (!Context) return null
 
 	if (typeof options === 'number') {
 		options = {sampleRate: options}

--- a/index.js
+++ b/index.js
@@ -3,12 +3,12 @@
 var cache = {}
 
 module.exports = function getContext (options) {
-  if (!window) return null
-  
-  var OfflineContext = window.OfflineAudioContext || window.webkitOfflineAudioContext
-  var Context = window.AudioContext || window.webkitAudioContext
-  
-  if (!Context) return null
+	if (!window) return null
+	
+	var OfflineContext = window.OfflineAudioContext || window.webkitOfflineAudioContext
+	var Context = window.AudioContext || window.webkitAudioContext
+	
+	if (!Context) return null
 
 	if (typeof options === 'number') {
 		options = {sampleRate: options}

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 var cache = {}
 
 module.exports = function getContext (options) {
-	if (!window) return null
+	if (typeof window === 'undefined') return null
 	
 	var OfflineContext = window.OfflineAudioContext || window.webkitOfflineAudioContext
 	var Context = window.AudioContext || window.webkitAudioContext

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "A WebAudio Context singleton",
   "version": "1.0.1",
   "scripts": {
-    "test": "browserify test.js | tape-run"
+    "test": "browserify test.js | tape-run && node test"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -10,9 +10,6 @@
     "url": "git://github.com/audiojs/audio-context.git"
   },
   "homepage": "https://github.com/audiojs/audio-context",
-  "dependencies": {
-    "global": "^4.3.1"
-  },
   "devDependencies": {
     "browserify": "^14.3.0",
     "is-browser": "^2.0.1",
@@ -22,6 +19,7 @@
   "keywords": [
     "webaudio",
     "audio",
+    "audiojs",
     "context",
     "singleton"
   ],

--- a/test.js
+++ b/test.js
@@ -63,3 +63,9 @@ isBrowser && test('exports audio-context/offline', function(t){
   t.end();
 });
 
+// Non-browser test, returns null
+!isBrowser && test('returns null in non-browser env', function(t){
+  var ctx = createContext()
+  t.is(ctx, null)
+  t.end()
+})


### PR DESCRIPTION
I looked at the source for `global/window`, and I was wondering if this behavior would be just as good without needing the dependency.  Also makes it so `window` only accessed when `getContext` is called (possibly better for the isomorphic packages)